### PR TITLE
glibc 2.28 removed the define _STDIO_USES_IOSTREAM (which was has bee…

### DIFF
--- a/ipl/cfuncs/fpoll.c
+++ b/ipl/cfuncs/fpoll.c
@@ -60,11 +60,8 @@ int fpoll(int argc, descriptor *argv)	/*: await data from file */
 
    /* check for data already in buffer */
    /* there's no legal way to do this in C; we cheat */
-#if defined(__GLIBC__) && defined(_STDIO_USES_IOSTREAM)	/* new GCC library */
+#if defined(__GLIBC__)                  /* New GCC library */
    if (f->_IO_read_ptr < f->_IO_read_end)
-      RetArg(1);
-#elif defined(__GLIBC__)				/* old GCC library */
-   if (f->__bufp < f->__get_limit)
       RetArg(1);
 #elif defined(_FSTDIO)					/* new BSD library */
    if (f->_r > 0)
@@ -92,7 +89,7 @@ int fpoll(int argc, descriptor *argv)	/*: await data from file */
 
    if (r > 0)
       RetArg(1);			/* success */
-   else if (r == 0)			
+   else if (r == 0)
       Fail;				/* timeout */
    else
       ArgError(1, 214);			/* I/O error */


### PR DESCRIPTION
…n around since 1995).  Remove old glibc method

I checked the back level versions of glibc.  The _STDIO_USES_IOSTREAM is in the earliest 2.0.1 tarball on the glibc site.  There was one tarball for 1.09.1 that didn't have the above define.  I believe that this is a "safe" update.

I did a quick compile test on a gentoo system using a glibc 2.27 level and it compiled cleanly.