### PR TITLE
Fix signed overflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,7 @@ Ibin:		bin/icont
 
 D=$(dest)
 Install:
-		mkdir $D
-		mkdir $D/bin $D/lib $D/doc $D/man $D/man/man1
+		mkdir -p $D/bin $D/lib $D/doc $D/man/man1
 		cp README $D
 		cp bin/[cflpvwx]* $D/bin
 		cp bin/icon[tx]* $D/bin

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #  configuration parameters
 VERSION=v951
 name=unspecified
-dest=/must/specify/dest/
+dest=
 
 
 ##################################################################
@@ -86,6 +86,15 @@ Ibin:		bin/icont
 
 D=$(dest)
 Install:
+		@if [ "x$D" = "x" -o -e "$D" ]; then \
+			echo ""; \
+			echo "To install Icon, run"; \
+			echo ""; \
+			echo "	make Install dest=xxxx"; \
+			echo ""; \
+			echo "where xxxx is the name of a directory to create."; \
+			echo ""; \
+			false; fi
 		mkdir -p $D/bin $D/lib $D/doc $D/man/man1
 		cp README $D
 		cp bin/[cflpvwx]* $D/bin

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -23,14 +23,14 @@ default:  $(MADE)
 
 icon.txt: ../man/man1/icon.1 clnroff.sed
 	nroff -Tascii -man ../man/man1/icon.1 | \
-	    sed -f clnroff.sed | uniq >icon.txt
+	    sed -f clnroff.sed | uniq >$@
 
 icont.txt: ../man/man1/icont.1 clnroff.sed
 	nroff -Tascii -man ../man/man1/icont.1 | \
-	    sed -f clnroff.sed | uniq >icont.txt
+	    sed -f clnroff.sed | uniq >$@
 
 faq.txt:  faq.htm
-	lynx -nolist -dump -justify=off -width=79 faq.htm >faq.txt
+	lynx -nolist -dump -justify=off -width=79 faq.htm >$@
 
 
 #  check integrity of HTML files.

--- a/ipl/Makefile
+++ b/ipl/Makefile
@@ -18,7 +18,7 @@ cfuncs/libcfunc.so:  ../bin/icont
 #  Make C functions.  Only called if LoadFunc is defined.
 
 Cfunctions:
-	cd cfuncs; LPATH= $(MAKE) ICONT=../../bin/icont
+	cd cfuncs; LPATH= $(MAKE) IC=../../bin/icont
 	cp cfuncs/*.u? ../lib
 	cp cfuncs/libcfunc.so ../bin
 

--- a/ipl/cfuncs/Makefile
+++ b/ipl/cfuncs/Makefile
@@ -6,13 +6,14 @@
 
 include ../../Makedefs
 
-ICONT = icont
+IC = icont
 IFLAGS = -us
 
 FUNCLIB = libcfunc.so
 
-.SUFFIXES: .c .o
+.SUFFIXES: .c .o .icn .u2
 .c.o:			; $(CC) $(CFLAGS) $(CFDYN) -c $<
+.icn.u2:		; $(IC) $(IFLAGS) -c $<
 
 FUNCS = bitcount.o external.o files.o fpoll.o internal.o lgconv.o osf.o \
 	pack.o ppm.o process.o tconnect.o
@@ -33,7 +34,6 @@ $(FUNCS):	icall.h
 # Icon interface
 
 cfunc.u2:	cfunc.icn
-		$(ICONT) $(IFLAGS) -c $<
 cfunc.icn:	$(CSRC) mkfunc.sh
 		sh mkfunc.sh $(FUNCLIB) $(FUNCS) >$@
 

--- a/ipl/cfuncs/Makefile
+++ b/ipl/cfuncs/Makefile
@@ -25,7 +25,7 @@ default:	cfunc.u2 $(FUNCLIB)
 # library
 
 $(FUNCLIB):	$(FUNCS) mklib.sh
-		CC="$(CC)" CFLAGS="$(CFLAGS)" BIN="../../bin" \
+		CC="$(CC)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" BIN="../../bin" \
 		    sh mklib.sh $(FUNCLIB) $(FUNCS)
 $(FUNCS):	icall.h
 

--- a/ipl/cfuncs/Makefile
+++ b/ipl/cfuncs/Makefile
@@ -33,9 +33,9 @@ $(FUNCS):	icall.h
 # Icon interface
 
 cfunc.u2:	cfunc.icn
-		$(ICONT) $(IFLAGS) -c cfunc.icn
+		$(ICONT) $(IFLAGS) -c $<
 cfunc.icn:	$(CSRC) mkfunc.sh
-		sh mkfunc.sh $(FUNCLIB) $(FUNCS) >cfunc.icn
+		sh mkfunc.sh $(FUNCLIB) $(FUNCS) >$@
 
 
 # cleanup

--- a/ipl/cfuncs/mklib.sh
+++ b/ipl/cfuncs/mklib.sh
@@ -12,27 +12,27 @@ SYS=`uname -s`
 set -x
 case "$SYS" in
    Linux*|*BSD*|GNU*)
-      $CC -shared -o $LIBNAME -fPIC "$@";;
+      $CC $CFLAGS $LDFLAGS -shared -fPIC -o $LIBNAME "$@";;
    CYGWIN*)
       # move the win32 import library for iconx.exe callbacks
       # created when iconx.exe was built
       if [ -e $BIN/../src/runtime/iconx.a ]; then
          mv $BIN/../src/runtime/iconx.a $BIN
       fi
-      $CC -shared -Wl,--enable-auto-import -o $LIBNAME "$@" $BIN/iconx.a;;
+      $CC $CFLAGS $LDFLAGS -shared -Wl,--enable-auto-import -o $LIBNAME "$@" $BIN/iconx.a;;
    Darwin*)
-      $CC -bundle -undefined suppress -flat_namespace -o $LIBNAME "$@";;
+      $CC $CFLAGS $LDFLAGS -bundle -undefined suppress -flat_namespace -o $LIBNAME "$@";;
    SunOS*)
-      $CC $CFLAGS -G -o $LIBNAME "$@" -lc -lsocket;;
+      $CC $CFLAGS $LDFLAGS -G -o $LIBNAME "$@" -lc -lsocket;;
    HP-UX*)
-      ld -b -o $LIBNAME "$@";;
+      ld $LDFLAGS -b -o $LIBNAME "$@";;
    IRIX*)
-      ld -shared -o $LIBNAME "$@";;
+      ld $LDFLAGS -shared -o $LIBNAME "$@";;
    OSF*)
-      ld -shared -expect_unresolved '*' -o $LIBNAME "$@" -lc;;
+      ld $LDFLAGS -shared -expect_unresolved '*' -o $LIBNAME "$@" -lc;;
    AIX*)
       # this may not be quite right; it doesn't seem to work yet...
-      ld -bM:SRE -berok -bexpall -bnoentry -bnox -bnogc -brtl -o $LIBNAME "$@";;
+      ld $LDFLAGS -bM:SRE -berok -bexpall -bnoentry -bnox -bnogc -brtl -o $LIBNAME "$@";;
    *)
       set -
       echo 1>&2 "don't know how to make libraries under $SYS"

--- a/ipl/docs/iconmake.txt
+++ b/ipl/docs/iconmake.txt
@@ -23,16 +23,15 @@ FILES=|>List of component files, space separated, using .u1 suffix<|
 #
 #  Option flag definitions, etc.
 #
-ICFLAGS=-s
+IC=icont
 IFLAGS=-s
-ICONT=icont
 
 #
 #  Implicit rule for making ucode files.
 #
-.SUFFIXES: .u1 .icn
+.SUFFIXES: .icn .u1
 .icn.u1:
-	$(ICONT) -c $(ICFLAGS) $*
+	$(IC) $(IFLAGS) -c $<
 
 #
 #  Explicit rules for making an Icon program.
@@ -40,5 +39,4 @@ ICONT=icont
 all:	$(PROGRAM)
 
 $(PROGRAM): $(FILES)
-	$(ICONT) -o $(PROGRAM) $(IFLAGS) $(FILES)
-
+	$(IC) $(IFLAGS) -o $@ $(FILES)

--- a/ipl/gpacks/vib/Makefile
+++ b/ipl/gpacks/vib/Makefile
@@ -17,7 +17,7 @@ OBJ = vib.u2 vibbttn.u2 vibedit.u2 vibfile.u2 vibglbl.u2 \
 	giftoppm $< | ppmtopgm | pnmtops -scale .75 >$@
 
 vib:	$(OBJ)
-	$(ITRAN) -o vib $(OBJ)
+	$(ITRAN) -o $@ $(OBJ)
 
 $(OBJ):	vibdefn.icn
 
@@ -26,7 +26,7 @@ ipd doc: ipd265.ps
 
 ipd265.ps:	ipd265.bibl fig1.ps fig2.ps
 	bib -t stdn -p /r/che/usr/ralph/docs/reg.index <ipd265.bibl | \
-	    psfig | psroff -t >ipd265.ps
+	    psfig | psroff -t >$@
 
 Iexe:	vib
 	cp vib ../../iexe/

--- a/ipl/gpacks/vib/Makefile
+++ b/ipl/gpacks/vib/Makefile
@@ -1,8 +1,7 @@
 #  Makefile for vib, the Visual Interface Builder
 
-ICONT = icont
+IC = icont
 IFLAGS = -us
-ITRAN = $(ICONT) $(IFLAGS)
 
 OBJ = vib.u2 vibbttn.u2 vibedit.u2 vibfile.u2 vibglbl.u2 \
 	viblabel.u2 vibline.u2 viblist.u2 vibmenu.u2 vibradio.u2 \
@@ -10,14 +9,14 @@ OBJ = vib.u2 vibbttn.u2 vibedit.u2 vibfile.u2 vibglbl.u2 \
 
 .SUFFIXES: .icn .u2 .gif .ps
 
-.icn.u2:	; $(ITRAN) -c $<
-.icn:		; $(ITRAN) $<
+.icn.u2:	; $(IC) $(IFLAGS) -c $<
+.icn:		; $(IC) $(IFLAGS) $<
 
 .gif.ps:
 	giftoppm $< | ppmtopgm | pnmtops -scale .75 >$@
 
 vib:	$(OBJ)
-	$(ITRAN) -o $@ $(OBJ)
+	$(IC) $(IFLAGS) -o $@ $(OBJ)
 
 $(OBJ):	vibdefn.icn
 

--- a/ipl/packs/loadfunc/Makefile
+++ b/ipl/packs/loadfunc/Makefile
@@ -28,7 +28,7 @@ libnames.icn:	Makefile
 		echo '$$define FUNCLIB "./$(FUNCLIB)"'	>libnames.icn
 
 $(FUNCLIB):	$(FUNCS)
-		CC="$(CC)" CFLAGS="$(CFLAGS)" BIN="../../../bin" \
+		CC="$(CC)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" BIN="../../../bin" \
 			sh $(MKLIB) $(FUNCLIB) $(FUNCS)
 
 

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -8,7 +8,7 @@ OBJS =	long.o getopt.o time.o filepart.o identify.o strtbl.o rtdb.o\
 common:		$(OBJS) gpxmaybe
 
 patchstr:	patchstr.c
-		$(CC) $(CFLAGS) -o $@ patchstr.c
+		$(CC) $(CFLAGS) $(LDFLAGS) -o $@ patchstr.c
 
 gpxmaybe:
 		-if [ "x$(XL)" != "x" ]; then $(MAKE) $(GDIR); fi
@@ -25,7 +25,7 @@ $(OBJS): ../h/define.h ../h/arch.h ../h/config.h ../h/cstructs.h \
 	  ../h/typedefs.h ../h/mproto.h ../h/cpuconf.h
 
 infer:		infer.c
-		$(CC) $(CFLAGS) -o $@ infer.c
+		$(CC) $(CFLAGS) $(LDFLAGS) -o $@ infer.c
 
 ../h/arch.h:	infer
 		./infer >$@

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -24,8 +24,10 @@ wincap:
 $(OBJS): ../h/define.h ../h/arch.h ../h/config.h ../h/cstructs.h \
 	  ../h/typedefs.h ../h/mproto.h ../h/cpuconf.h
 
-../h/arch.h:	infer.c
+infer:		infer.c
 		$(CC) $(CFLAGS) -o infer infer.c
+
+../h/arch.h:	infer
 		./infer >../h/arch.h
 
 identify.o: ../h/version.h

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -8,7 +8,7 @@ OBJS =	long.o getopt.o time.o filepart.o identify.o strtbl.o rtdb.o\
 common:		$(OBJS) gpxmaybe
 
 patchstr:	patchstr.c
-		$(CC) $(CFLAGS) -o patchstr patchstr.c
+		$(CC) $(CFLAGS) -o $@ patchstr.c
 
 gpxmaybe:
 		-if [ "x$(XL)" != "x" ]; then $(MAKE) $(GDIR); fi
@@ -25,10 +25,10 @@ $(OBJS): ../h/define.h ../h/arch.h ../h/config.h ../h/cstructs.h \
 	  ../h/typedefs.h ../h/mproto.h ../h/cpuconf.h
 
 infer:		infer.c
-		$(CC) $(CFLAGS) -o infer infer.c
+		$(CC) $(CFLAGS) -o $@ infer.c
 
 ../h/arch.h:	infer
-		./infer >../h/arch.h
+		./infer >$@
 
 identify.o: ../h/version.h
 
@@ -52,13 +52,13 @@ lextab.h yacctok.h:	tokens.txt op.txt mktoktab
 			./mktoktab
 
 mktoktab:		mktoktab.icn
-			icont -s mktoktab.icn
+			icont -s $<
 
 fixgram:		fixgram.icn
-			icont -s fixgram.icn
+			icont -s $<
 
 pscript:		pscript.icn
-			icont -s pscript.icn
+			icont -s $<
 
 
 

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -1,5 +1,11 @@
 include ../../Makedefs
 
+IC = icont
+IFLAGS = -s
+
+.SUFFIXES: .icn
+.icn:
+		$(IC) $(IFLAGS) $<
 
 OBJS =	long.o getopt.o time.o filepart.o identify.o strtbl.o rtdb.o\
 	munix.o literals.o rswitch.o alloc.o long.o getopt.o time.o\
@@ -52,14 +58,8 @@ lextab.h yacctok.h:	tokens.txt op.txt mktoktab
 			./mktoktab
 
 mktoktab:		mktoktab.icn
-			icont -s $<
-
 fixgram:		fixgram.icn
-			icont -s $<
-
 pscript:		pscript.icn
-			icont -s $<
-
 
 
 #  The following section is commented out because it does not need to be
@@ -79,4 +79,3 @@ pscript:		pscript.icn
 #	typespec <typespec.txt >icontype.h
 #
 #typespec: typespec.icn
-#	icont typespec

--- a/src/h/rmacros.h
+++ b/src/h/rmacros.h
@@ -213,12 +213,12 @@
 /*
  * Set bit b in cset c.
  */
-#define Setb(b,c)	(*CsetPtr(b,c) |= (01 << CsetOff(b)))
+#define Setb(b,c)	(*CsetPtr(b,c) |= (1u << CsetOff(b)))
 
 /*
  * Test bit b in cset c.
  */
-#define Testb(b,c)	((*CsetPtr(b,c) >> CsetOff(b)) & 01)
+#define Testb(b,c)	((*CsetPtr(b,c) >> CsetOff(b)) & 1u)
 
 /*
  * Check whether a set or table needs resizing.

--- a/src/icont/Makefile
+++ b/src/icont/Makefile
@@ -19,8 +19,8 @@ COBJS =		../common/long.o ../common/getopt.o ../common/alloc.o \
 
 
 icont:		$(OBJS) $(COBJS)
-		$(CC) $(CFLAGS) $(LDFLAGS) -o icont $(OBJS) $(COBJS)
-		cp icont ../../bin
+		$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJS) $(COBJS)
+		cp $@ ../../bin
 		strip ../../bin/icont$(EXE)
 		(cd ../../bin; rm -f icon icon.exe; ln -s icont icon)
 
@@ -60,13 +60,13 @@ opcode.o:	opcode.h ../h/opdefs.h
 #  hdr.h is always built, to simplify the Makefile,
 #  but it is only actually used if BinHeader is define.
 hdr.h:		newhdr ixhdr.hdr
-		./newhdr -o hdr.h ixhdr.hdr
+		./newhdr -o $@ ixhdr.hdr
 newhdr:		newhdr.c ../h/define.h ../h/config.h ../h/gsupport.h
-		$(CC) $(CFLAGS) $(LDFLAGS) -o newhdr newhdr.c
+		$(CC) $(CFLAGS) $(LDFLAGS) -o $@ newhdr.c
 ixhdr.hdr:	ixhdr.c ../h/define.h ../h/config.h ../h/header.h $(COBJS)
-		$(CC) $(CFLAGS) $(LDFLAGS) -o ixhdr.hdr \
+		$(CC) $(CFLAGS) $(LDFLAGS) -o $@ \
 			ixhdr.c ../common/alloc.o ../common/munix.o
-		strip ixhdr.hdr
+		strip $@
 
 
 
@@ -96,13 +96,13 @@ ixhdr.hdr:	ixhdr.c ../h/define.h ../h/config.h ../h/header.h $(COBJS)
 #
 #tgram.g:	tgrammar.c ../h/define.h ../h/grammar.h \
 #			../common/yacctok.h ../common/fixgram 
-#		$(CC) -E -C tgrammar.c | ../common/fixgram >tgram.g
+#		$(CC) -E -C tgrammar.c | ../common/fixgram >$@
 #
 #../h/kdefs.h keyword.h:	../runtime/keyword.r mkkwd
 #		./mkkwd <../runtime/keyword.r
 #
 #trash:		trash.icn
-#		icont -s trash.icn
+#		icont -s $<
 #
 #mkkwd:		mkkwd.icn
-#		icont -s mkkwd.icn
+#		icont -s $<

--- a/src/icont/Makefile
+++ b/src/icont/Makefile
@@ -2,6 +2,12 @@
 
 include ../../Makedefs
 
+IC = icont
+IFLAGS = -s
+
+.SUFFIXES: .icn
+.icn:
+		$(IC) $(IFLAGS) $<
 
 HFILES =	../h/define.h ../h/config.h ../h/cpuconf.h ../h/gsupport.h \
 		   ../h/mproto.h ../h/typedefs.h ../h/cstructs.h
@@ -102,7 +108,4 @@ ixhdr.hdr:	ixhdr.c ../h/define.h ../h/config.h ../h/header.h $(COBJS)
 #		./mkkwd <../runtime/keyword.r
 #
 #trash:		trash.icn
-#		icont -s $<
-#
 #mkkwd:		mkkwd.icn
-#		icont -s $<

--- a/src/rtt/Makefile
+++ b/src/rtt/Makefile
@@ -22,7 +22,7 @@ OBJ = $(ROBJS) $(POBJS) $(COBJS)
 
 
 rtt:	$(OBJ)
-	$(CC) $(LDFLAGS) -o rtt $(OBJ)
+	$(CC) $(LDFLAGS) -o $@ $(OBJ)
 
 library:	$(OBJ)
 		rm -rf rtt.a
@@ -38,37 +38,37 @@ rttparse.o : ../h/gsupport.h ../h/config.h ../h/cstructs.h \
 	../h/mproto.h ../h/typedefs.h ../h/cpuconf.h ../h/define.h
 
 pout.o: $(PP_DIR)pout.c $(P_DOT_H)
-	$(CC) $(CFLAGS) -c $(PP_DIR)pout.c
+	$(CC) $(CFLAGS) -c $<
 
 pchars.o: $(PP_DIR)pchars.c $(P_DOT_H)
-	$(CC) $(CFLAGS) -c $(PP_DIR)pchars.c
+	$(CC) $(CFLAGS) -c $<
 
 perr.o: $(PP_DIR)perr.c $(P_DOT_H)
-	$(CC) $(CFLAGS) -c $(PP_DIR)perr.c
+	$(CC) $(CFLAGS) -c $<
 
 pmem.o: $(PP_DIR)pmem.c $(P_DOT_H)
-	$(CC) $(CFLAGS) -c $(PP_DIR)pmem.c
+	$(CC) $(CFLAGS) -c $<
 
 bldtok.o: $(PP_DIR)bldtok.c $(P_DOT_H)
-	$(CC) $(CFLAGS) -c $(PP_DIR)bldtok.c
+	$(CC) $(CFLAGS) -c $<
 
 macro.o: $(PP_DIR)macro.c $(P_DOT_H)
-	$(CC) $(CFLAGS) -c $(PP_DIR)macro.c
+	$(CC) $(CFLAGS) -c $<
 
 preproc.o: $(PP_DIR)preproc.c $(P_DOT_H)
-	$(CC) $(CFLAGS) -c $(PP_DIR)preproc.c
+	$(CC) $(CFLAGS) -c $<
 
 evaluate.o: $(PP_DIR)evaluate.c $(P_DOT_H)
-	$(CC) $(CFLAGS) -c $(PP_DIR)evaluate.c
+	$(CC) $(CFLAGS) -c $<
 
 files.o: $(PP_DIR)files.c $(P_DOT_H)
-	$(CC) $(CFLAGS) -c $(PP_DIR)files.c
+	$(CC) $(CFLAGS) -c $<
 
 gettok.o: $(PP_DIR)gettok.c $(P_DOT_H)
-	$(CC) $(CFLAGS) -c $(PP_DIR)gettok.c
+	$(CC) $(CFLAGS) -c $<
 
 pinit.o: $(PP_DIR)pinit.c $(P_DOT_H)
-	$(CC) $(CFLAGS) -c $(PP_DIR)pinit.c
+	$(CC) $(CFLAGS) -c $<
 
 #
 # The following entry is commented out because it is not normally

--- a/src/rtt/Makefile
+++ b/src/rtt/Makefile
@@ -22,7 +22,7 @@ OBJ = $(ROBJS) $(POBJS) $(COBJS)
 
 
 rtt:	$(OBJ)
-	$(CC) $(LDFLAGS) -o $@ $(OBJ)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJ)
 
 library:	$(OBJ)
 		rm -rf rtt.a

--- a/src/rtt/Makefile
+++ b/src/rtt/Makefile
@@ -38,37 +38,37 @@ rttparse.o : ../h/gsupport.h ../h/config.h ../h/cstructs.h \
 	../h/mproto.h ../h/typedefs.h ../h/cpuconf.h ../h/define.h
 
 pout.o: $(PP_DIR)pout.c $(P_DOT_H)
-	$(CC) -c $(CFLAGS) $(PP_DIR)pout.c 
+	$(CC) $(CFLAGS) -c $(PP_DIR)pout.c
 
 pchars.o: $(PP_DIR)pchars.c $(P_DOT_H)
-	$(CC) -c $(CFLAGS) $(PP_DIR)pchars.c 
+	$(CC) $(CFLAGS) -c $(PP_DIR)pchars.c
 
 perr.o: $(PP_DIR)perr.c $(P_DOT_H)
-	$(CC) -c $(CFLAGS) $(PP_DIR)perr.c
+	$(CC) $(CFLAGS) -c $(PP_DIR)perr.c
 
 pmem.o: $(PP_DIR)pmem.c $(P_DOT_H)
-	$(CC) -c $(CFLAGS) $(PP_DIR)pmem.c
+	$(CC) $(CFLAGS) -c $(PP_DIR)pmem.c
 
 bldtok.o: $(PP_DIR)bldtok.c $(P_DOT_H)
-	$(CC) -c $(CFLAGS) $(PP_DIR)bldtok.c
+	$(CC) $(CFLAGS) -c $(PP_DIR)bldtok.c
 
 macro.o: $(PP_DIR)macro.c $(P_DOT_H)
-	$(CC) -c $(CFLAGS) $(PP_DIR)macro.c
+	$(CC) $(CFLAGS) -c $(PP_DIR)macro.c
 
 preproc.o: $(PP_DIR)preproc.c $(P_DOT_H)
-	$(CC) -c $(CFLAGS) $(PP_DIR)preproc.c
+	$(CC) $(CFLAGS) -c $(PP_DIR)preproc.c
 
 evaluate.o: $(PP_DIR)evaluate.c $(P_DOT_H)
-	$(CC) -c $(CFLAGS) $(PP_DIR)evaluate.c
+	$(CC) $(CFLAGS) -c $(PP_DIR)evaluate.c
 
 files.o: $(PP_DIR)files.c $(P_DOT_H)
-	$(CC) -c $(CFLAGS) $(PP_DIR)files.c
+	$(CC) $(CFLAGS) -c $(PP_DIR)files.c
 
 gettok.o: $(PP_DIR)gettok.c $(P_DOT_H)
-	$(CC) -c $(CFLAGS) $(PP_DIR)gettok.c
+	$(CC) $(CFLAGS) -c $(PP_DIR)gettok.c
 
 pinit.o: $(PP_DIR)pinit.c $(P_DOT_H)
-	$(CC) -c $(CFLAGS) $(PP_DIR)pinit.c
+	$(CC) $(CFLAGS) -c $(PP_DIR)pinit.c
 
 #
 # The following entry is commented out because it is not normally

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -30,7 +30,7 @@ SUFFIXES = .r .c .o
 
 iconx: $(COBJS) $(XOBJS)
 	cd ../common; $(MAKE)
-	$(CC) $(RLINK) -o $@ $(XOBJS) $(COBJS) $(XL) $(RLIBS) $(TLIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(RLINK) -o $@ $(XOBJS) $(COBJS) $(XL) $(RLIBS) $(TLIBS)
 	cp $@ ../../bin
 	strip $(SFLAGS) ../../bin/iconx$(EXE)
 

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -24,7 +24,7 @@ XOBJS =	cnv.o data.o def.o errmsg.o fconv.o fload.o fmath.o\
 
 RTT = ../rtt/rtt
 SUFFIXES = .r .c .o
-.r.o:	; $(RTT) -x $*.r && $(CC) -o $*.o -c $(CFLAGS) x$*.c && rm x$*.c
+.r.o:	; $(RTT) -x $*.r && $(CC) $(CFLAGS) -c -o $*.o x$*.c && rm x$*.c
 .r.c:	; $(RTT) -x $*.r
 
 

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -24,14 +24,14 @@ XOBJS =	cnv.o data.o def.o errmsg.o fconv.o fload.o fmath.o\
 
 RTT = ../rtt/rtt
 SUFFIXES = .r .c .o
-.r.o:	; $(RTT) -x $*.r && $(CC) $(CFLAGS) -c -o $*.o x$*.c && rm x$*.c
-.r.c:	; $(RTT) -x $*.r
+.r.o:	; $(RTT) -x $< && $(CC) $(CFLAGS) -c -o $@ x$*.c && rm x$*.c
+.r.c:	; $(RTT) -x $<
 
 
 iconx: $(COBJS) $(XOBJS)
 	cd ../common; $(MAKE)
-	$(CC) $(RLINK) -o iconx $(XOBJS) $(COBJS) $(XL) $(RLIBS) $(TLIBS)
-	cp iconx ../../bin
+	$(CC) $(RLINK) -o $@ $(XOBJS) $(COBJS) $(XL) $(RLIBS) $(TLIBS)
+	cp $@ ../../bin
 	strip $(SFLAGS) ../../bin/iconx$(EXE)
 
 $(COBJS):

--- a/src/runtime/cnv.r
+++ b/src/runtime/cnv.r
@@ -686,7 +686,6 @@ char *s;
    {
    register char *p;
    long ival;
-   static char *maxneg = MaxNegInt;
 
    p = s + MaxCvtLen - 1;
    ival = num;
@@ -698,9 +697,9 @@ char *s;
 	 ival /= 10L;
 	 } while (ival != 0L);
    else {
-      if (ival == -ival) {      /* max negative value */
-	 p -= strlen (maxneg);
-	 sprintf (p, "%s", maxneg);
+      if (ival == MinLong) {
+	 p -= strlen (MaxNegInt);
+	 sprintf (p, MaxNegInt);
          }
       else {
 	ival = -ival;

--- a/src/runtime/rlrgint.r
+++ b/src/runtime/rlrgint.r
@@ -1824,7 +1824,7 @@ word i;
    if (i > 0) {
       /* scan bits left to right.  skip leading 1. */
       while (--n >= 0)
-         if (i & ((word)1 << n))
+         if (i & ((uword)1 << n))
 	    break;
       /* then, for each zero, square the partial result;
          for each one, square it and multiply it by a */
@@ -1832,7 +1832,7 @@ word i;
       while (--n >= 0) {
          if (bigmul(dx, dx, dx) == Error)
 	    return Error;
-         if (i & ((word)1 << n))
+         if (i & ((uword)1 << n))
             if (bigmul(dx, da, dx) == Error)
 	       return Error;
          }
@@ -1880,7 +1880,7 @@ dptr dx;
 
       /* scan bits left to right.  skip leading 1. */
       while (--n >= 0)
-         if (i & ((word)1 << n))
+         if (i & ((uword)1 << n))
 	    break;
       /* then, for each zero, square the partial result;
          for each one, square it and multiply it by a */
@@ -1901,7 +1901,7 @@ dptr dx;
                isbig = (Type(*dx) == T_Lrgint);
                }
             }
-         if (i & ((word)1 << n)) {
+         if (i & ((uword)1 << n)) {
             if (isbig) {
                if (bigmuli(dx, a, dx) == Error)
 		  return Error;

--- a/src/wincap/Makefile
+++ b/src/wincap/Makefile
@@ -6,7 +6,7 @@ W32DEFS = -mwin32
 OBJS = copy.o dibutil.o errors.o file.o
 
 .c.o:
-	$(CC) $(CFLAGS) $(W32DEFS) -c $*.c
+	$(CC) $(CFLAGS) $(W32DEFS) -c $<
 
 libWincap.a: $(OBJS)
 	rm -f $@

--- a/src/wincap/Makefile
+++ b/src/wincap/Makefile
@@ -6,7 +6,7 @@ W32DEFS = -mwin32
 OBJS = copy.o dibutil.o errors.o file.o
 
 .c.o:
-	$(CC) -c $(CFLAGS) $(W32DEFS) $*.c
+	$(CC) $(CFLAGS) $(W32DEFS) -c $*.c
 
 libWincap.a: $(OBJS)
 	rm -f $@

--- a/src/xpm/Makefile
+++ b/src/xpm/Makefile
@@ -14,7 +14,7 @@ OBJS1 = data.o create.o misc.o rgb.o scan.o parse.o hashtable.o \
 	  XpmWrFFrI.o XpmRdFToI.o XpmCrIFData.o XpmCrDataFI.o
 
 .c.o:
-	$(CC) -c $(CFLAGS) $(XPMDEFS) $*.c
+	$(CC) $(CFLAGS) $(XPMDEFS) -c $*.c
 
 
 libXpm.a: $(OBJS1)

--- a/src/xpm/Makefile
+++ b/src/xpm/Makefile
@@ -14,7 +14,7 @@ OBJS1 = data.o create.o misc.o rgb.o scan.o parse.o hashtable.o \
 	  XpmWrFFrI.o XpmRdFToI.o XpmCrIFData.o XpmCrDataFI.o
 
 .c.o:
-	$(CC) $(CFLAGS) $(XPMDEFS) -c $*.c
+	$(CC) $(CFLAGS) $(XPMDEFS) -c $<
 
 
 libXpm.a: $(OBJS1)


### PR DESCRIPTION
This fixes a test failure with recent versions of GCC, plus a few more errors from its undefined behavior sanitizer.

This builds on the Makefile fixes of #3 to allow `CFLAGS="-fsanitize=undefined"` to work properly.  There are several more instances of signed overflow that are detected; fixing those is more involved than I'm comfortable with.