### PR TITLE
ipl/cfuncs/fpoll: add case to build with musl library

### DIFF
--- a/doc/relnotes.htm
+++ b/doc/relnotes.htm
@@ -52,7 +52,7 @@ Mac OS 10.10 (&ldquo;Yosemite&rdquo;).
 <P> Support for pre-1995 versions of the GNU C library was removed to
 adapt to internal changes in version 2.28 of 2018.
 
-<P>The <A HREf="https://musl.libc.org/"><CODE>musl</CODE></A> C library can be
+<P>The <A HREF="https://musl.libc.org/"><CODE>musl</CODE></A> C library can be
 used if <CODE>_MUSL</CODE> is defined manually in CFLAGS when configuring.
 
 <H3> Library changes </H3>

--- a/doc/relnotes.htm
+++ b/doc/relnotes.htm
@@ -52,6 +52,9 @@ Mac OS 10.10 (&ldquo;Yosemite&rdquo;).
 <P> Support for pre-1995 versions of the GNU C library was removed to
 adapt to internal changes in version 2.28 of 2018.
 
+<P>The <A HREf="https://musl.libc.org/"><CODE>musl</CODE></A> C library can be
+used if <CODE>_MUSL</CODE> is defined manually in CFLAGS when configuring.
+
 <H3> Library changes </H3>
 
 <P> As usual, some files in the Icon program library have been
@@ -252,7 +255,8 @@ Steve Wampler suggested the <CODE>gcd</CODE> liberalization.
 <BR>
 Sean Jensen fixed an ancient bug in the lexer.
 <BR>
-Cheyenne Wills provided the GNU C library fix.
+Cheyenne Wills provided the GNU C library fix
+and the <CODE>musl</CODE> adaptation.
 
 <HR>
 

--- a/ipl/cfuncs/fpoll.c
+++ b/ipl/cfuncs/fpoll.c
@@ -37,6 +37,10 @@
 #include <sys/types.h>
 #include <sys/time.h>
 
+#if defined(_MUSL)
+# include <stdio_ext.h>
+#endif
+
 #include "icall.h"
 
 int fpoll(int argc, descriptor *argv)	/*: await data from file */
@@ -69,6 +73,9 @@ int fpoll(int argc, descriptor *argv)	/*: await data from file */
       RetArg(1);
 #elif defined(_FSTDIO)					/* new BSD library */
    if (f->_r > 0)
+      RetArg(1);
+#elif defined(_MUSL)					/* MUSL library */
+   if (__freadahead(f))
       RetArg(1);
 #else							/* old AT&T library */
    if (f->_cnt > 0)

--- a/src/h/version.h
+++ b/src/h/version.h
@@ -12,7 +12,7 @@
  *  These are the only two entries that change any more.
  */
 #define VersionNumber "9.5.1+git"
-#define VersionDate "April 23, 2020"
+#define VersionDate "May 9, 2020"
 
 /*
  * Version number to insure format of data base matches version of iconc


### PR DESCRIPTION
When building with the musl library (an alternative to glibc), fpoll.c
fails due to the sensitivity of the internals of the FILE structure.

The musl library provides a function (__freadahead) that performs the
necessary test to see if data is available, however musl does not provide
a method to determine if the musl library is in use.

In order to build with the musl library, define the macro _MUSL via the
CFLAGS variable in Makedefs (e.g. CFLAGS=$(CFLAGS) -D_MUSL)