### PR TITLE
Fix converting -2^63 to a string.

### DIFF
--- a/src/runtime/cnv.r
+++ b/src/runtime/cnv.r
@@ -698,7 +698,7 @@ char *s;
 	 ival /= 10L;
 	 } while (ival != 0L);
    else {
-      if (ival == -ival) {      /* max negative value */
+      if (ival == MinLong) {      /* max negative value */
 	 p -= strlen (maxneg);
 	 sprintf (p, "%s", maxneg);
          }


### PR DESCRIPTION
In itos in cnv.r the statement if (ival == -ival) seems to be confusing
the optimizer for gcc.

The failure is showing up in lgint test - specifically testing binops for the value 2^63.

The following isolates the bug:
```
a := 2^63
b := -a
write(b)
```
Which produces garbage output.

Replace with a direct test for MinLong.