### PR TITLE
Allow larger strings

### DIFF
--- a/src/h/cpuconf.h
+++ b/src/h/cpuconf.h
@@ -31,7 +31,7 @@
       #define MaxLong  ((long int)0x7fffffffffffffff) /* largest long integer */
    #endif
 
-   #define MaxStrLen 017777777777L		/* maximum string length */
+   #define MaxStrLen 037777777777777777777L	/* maximum string length */
 
    #ifndef MaxNegInt
       #define MaxNegInt "-9223372036854775808"


### PR DESCRIPTION
Insrease Max string length from 2^27 to 2^31 on 32-bit platforms
and from 2^31 to 2^63 on 64-bit platforms.

Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>