### PR TITLE
Ensure obj dataype in data.r match obj definition

### DIFF
--- a/src/h/rstructs.h
+++ b/src/h/rstructs.h
@@ -81,6 +81,12 @@ struct b_list {			/* list-header block */
    union block *listtail;	/*   pointer to last list-element block */
    };
 
+/*
+ * b_proc and b_iproc must be kept identical in size and layout.  The
+ * only differences being entryp and ip_entryp and pname and ip_pname.
+ * See b_iproc for details.
+ */
+
 struct b_proc {			/* procedure block */
    word title;			/*   T_Proc */
    word blksize;		/*   size of block */

--- a/src/runtime/data.r
+++ b/src/runtime/data.r
@@ -9,28 +9,28 @@ struct b_proc Bnoproc;
  * External declarations for function blocks.
  */
 
-#define FncDef(p,n) extern struct b_proc Cat(B,p);
-#define FncDefV(p) extern struct b_proc Cat(B,p);
+#define FncDef(p,n) extern struct b_iproc Cat(B,p);
+#define FncDefV(p) extern struct b_iproc Cat(B,p);
 #passthru #undef exit
 #undef exit
 #include "../h/fdefs.h"
 #undef FncDef
 #undef FncDefV
 
-#define OpDef(p,n,s,u) extern struct b_proc Cat(B,p);
+#define OpDef(p,n,s,u) extern struct b_iproc Cat(B,p);
 #include "../h/odefs.h"
 #undef OpDef
 
-extern struct b_proc Bbscan;
-extern struct b_proc Bescan;
-extern struct b_proc Bfield;
-extern struct b_proc Blimit;
-extern struct b_proc Bllist;
+extern struct b_iproc Bbscan;
+extern struct b_iproc Bescan;
+extern struct b_iproc Bfield;
+extern struct b_iproc Blimit;
+extern struct b_iproc Bllist;
 
 
 
 
-struct b_proc *opblks[] = {
+struct b_iproc *opblks[] = {
 	NULL,
 #define OpDef(p,n,s,u) Cat(&B,p),
 #include "../h/odefs.h"

--- a/src/runtime/rdebug.r
+++ b/src/runtime/rdebug.r
@@ -360,7 +360,7 @@ static void showlevel(int n)
 #include "../h/opdefs.h"
 
 extern struct descrip value_tmp;		/* argument of Op_Apply */
-extern struct b_proc *opblks[];
+extern struct b_iproc *opblks[];
 
 
 /*
@@ -469,7 +469,7 @@ static void ttrace()
 
       default:
 
-         bp = opblks[lastop];
+         bp = (struct b_proc *)opblks[lastop];
          nargs = abs((int)bp->nparam);
          putc('{', stderr);
          if (lastop == Op_Bang || lastop == Op_Random)


### PR DESCRIPTION
When building with lto (Link Time Optimization) flags, the compiler discovered an inconsistency in the datatypes for the structures:
    BbScan, Bescan, Bfield, Blimit, and Bllist.

    [gcc-15] data.r: error: type of Bllist does not match original
        declaration [-Werror=lto-type-mismatch]

In rmacros.h, the macro OpBlock produces a structure definition of:

    struct b_iproc B{name} ...

In grttin.h the macro LibDcl is uses OpBlock to define structures.

The definitions for the structures BbScan, Bescan, Bfield, Blimit, and Bllist are generated in imisc.r and omisc.r via LibDcl's or OpBlock's.

However in data.r, the datatype for these structures are declared as struct b_proc.

To fix the lto problem, change the data type of the externs and the datatype of the opblks array to be b_iproc instead of b_proc so they properly match the datatypes in imisc and omisc.

Note this problem was discovered via gentoo's QA processing (see https://bugs.gentoo.org/940325)