### PR TITLE
Update Hurd build configuration

### DIFF
--- a/config/hurd/Makedefs
+++ b/config/hurd/Makedefs
@@ -11,5 +11,5 @@ CFLAGS = -O
 CFDYN = -fPIC
 RLINK = -Wl,-E
 RLIBS = -lm -ldl
-TLIBS =
-XLIBS = -L/usr/X11R6/lib -lXpm -lX11
+TLIBS = -lpthread
+XLIBS = -lXpm -lX11

--- a/config/hurd/status
+++ b/config/hurd/status
@@ -1,6 +1,6 @@
 System configuration:
 
-	Intel architecture running the GNU system
+	The GNU system (on all hardware platforms)
 
 Latest Icon version:
 


### PR DESCRIPTION
Synchronize the Hurd build configuration matching the Linux one:
- `TLIBS` properly links to pthreads
- `XLIBS` does not need the very old X11R6 link path
- mention that the configuration applies to all the architectures